### PR TITLE
Removing deprecated g_type_init() call from camnode.cpp

### DIFF
--- a/src/camnode.cpp
+++ b/src/camnode.cpp
@@ -841,7 +841,7 @@ int main(int argc, char** argv)
     global.phNode = new ros::NodeHandle();
 
 
-    g_type_init ();
+    //g_type_init ();
 
     // Print out some useful info.
     ROS_INFO ("Attached cameras:");


### PR DESCRIPTION
There's a deprecated call to g_type_init() in camnode.cpp.  When removed, this compiles fine under Indigo.
